### PR TITLE
Fix bug of after_{create,update,destroy}_commit callbacks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,9 @@ rvm:
 branches:
   only:
     - master
+env:
+  - RAILS_ENV=test
+before_script:
+  - (cd spec/dummy && bin/rails db:setup)
 after_script:
   - '[ ${TRAVIS_EVENT_TYPE} != "pull_request" ] && [ ${TRAVIS_BRANCH} = "master" ] && bundle exec codeclimate-test-reporter'

--- a/lib/everett/subject.rb
+++ b/lib/everett/subject.rb
@@ -33,7 +33,10 @@ module Everett
       callbacks = CALLBACKS.select { |callback| observer.respond_to?(callback) }
       return false if callbacks.empty?
 
-      callbacks.each { |callback| @model.public_send(callback, observer) }
+      # TODO: Rewrite the following line in the form of passing an observer to callbacks
+      # if after_{create,update,destroy}_commit comes to call an identically named method
+      # of a callback object (currently it always calls #after_commit).
+      callbacks.each { |callback| @model.public_send(callback) { observer.public_send(callback, self) } }
       !!@observers.add(observer)
     end
   end

--- a/spec/dummy/db/migrate/20161226150058_create_foos.rb
+++ b/spec/dummy/db/migrate/20161226150058_create_foos.rb
@@ -1,0 +1,8 @@
+class CreateFoos < ActiveRecord::Migration[5.0]
+  def change
+    create_table :foos do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -1,0 +1,20 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 20161226150058) do
+
+  create_table "foos", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+end

--- a/spec/lib/everett/subject_spec.rb
+++ b/spec/lib/everett/subject_spec.rb
@@ -79,7 +79,7 @@ describe Everett::Subject do
 
       context "when the observer isn't added yet" do
         it "should return true, and the instance is used to set callbacks" do
-          expect(model_class).to receive(defined_method).once.with(observer)
+          expect(model_class).to receive(defined_method).and_yield.once
           expect(subject).to eq true
         end
       end

--- a/spec/lib/everett_spec.rb
+++ b/spec/lib/everett_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Everett do
 
     describe "observed models" do
       subject { model_class }
-      it { is_expected.to have_received(defined_method).once.with(observer_class.instance) }
+      it { is_expected.to have_received(defined_method).once }
     end
 
     after do


### PR DESCRIPTION
I got the following error when I've created a new record of observed model (= `Foo`).

```
irb(main):001:0> Foo.create!
   (0.3ms)  begin transaction
  SQL (1.4ms)  INSERT INTO "foos" ("created_at", "updated_at") VALUES (?, ?)  [["created_at", 2016-12-26 16:44:37 UTC], ["updated_at", 2016-12-26 16:44:37 UTC]]
   (4.4ms)  commit transaction
NoMethodError: undefined method `after_commit' for #<FooObserver:0x007f803c4215a8 @observed_classes=#<Set: {}>>
	from /path/to/activesupport-5.0.0.1/lib/active_support/callbacks.rb:405:in `public_send'
	from /path/to/activesupport-5.0.0.1/lib/active_support/callbacks.rb:405:in `block in make_lambda'
	from /path/to/activesupport-5.0.0.1/lib/active_support/callbacks.rb:232:in `block in conditional'
	from /path/to/activesupport-5.0.0.1/lib/active_support/callbacks.rb:456:in `block in call'
	from /path/to/activesupport-5.0.0.1/lib/active_support/callbacks.rb:456:in `each'
	from /path/to/activesupport-5.0.0.1/lib/active_support/callbacks.rb:456:in `call'
	from /path/to/activesupport-5.0.0.1/lib/active_support/callbacks.rb:101:in `__run_callbacks__'
	from /path/to/activesupport-5.0.0.1/lib/active_support/callbacks.rb:750:in `_run_commit_callbacks'
	from /path/to/activerecord-5.0.0.1/lib/active_record/transactions.rb:354:in `committed!'
	from /path/to/activerecord-5.0.0.1/lib/active_record/connection_adapters/abstract/transaction.rb:87:in `commit_records'
	from /path/to/activerecord-5.0.0.1/lib/active_record/connection_adapters/abstract/transaction.rb:178:in `commit_transaction'
	from /path/to/activerecord-5.0.0.1/lib/active_record/connection_adapters/abstract/transaction.rb:202:in `within_new_transaction'
	from /path/to/activerecord-5.0.0.1/lib/active_record/connection_adapters/abstract/database_statements.rb:232:in `transaction'
	from /path/to/activerecord-5.0.0.1/lib/active_record/transactions.rb:211:in `transaction'
	from /path/to/activerecord-5.0.0.1/lib/active_record/transactions.rb:392:in `with_transaction_returning_status'
	from /path/to/activerecord-5.0.0.1/lib/active_record/transactions.rb:324:in `save!'
... 4 levels...
	from /path/to/railties-5.0.0.1/lib/rails/commands/console_helper.rb:9:in `start'
	from /path/to/railties-5.0.0.1/lib/rails/commands/commands_tasks.rb:78:in `console'
	from /path/to/railties-5.0.0.1/lib/rails/commands/commands_tasks.rb:49:in `run_command!'
	from /path/to/railties-5.0.0.1/lib/rails/commands.rb:18:in `<top (required)>'
	from /path/to/activesupport-5.0.0.1/lib/active_support/dependencies.rb:293:in `require'
	from /path/to/activesupport-5.0.0.1/lib/active_support/dependencies.rb:293:in `block in require'
	from /path/to/activesupport-5.0.0.1/lib/active_support/dependencies.rb:259:in `load_dependency'
	from /path/to/activesupport-5.0.0.1/lib/active_support/dependencies.rb:293:in `require'
	from /Users/yasaichi/rails50x/test_app/bin/rails:9:in `<top (required)>'
	from /path/to/activesupport-5.0.0.1/lib/active_support/dependencies.rb:287:in `load'
	from /path/to/activesupport-5.0.0.1/lib/active_support/dependencies.rb:287:in `block in load'
	from /path/to/activesupport-5.0.0.1/lib/active_support/dependencies.rb:259:in `load_dependency'
	from /path/to/activesupport-5.0.0.1/lib/active_support/dependencies.rb:287:in `load'
	from /usr/local/var/rbenv/versions/2.3.1/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /usr/local/var/rbenv/versions/2.3.1/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from -e:1:in `<main>'
```

As I looked over the [PR](https://github.com/rails/rails/pull/22516) where the three callbacks were introduced, I found the following things:

* They are just shortcuts for `after_commit`
* They call `#after_commit` of callback objects unlike the other callbacks
* They work well when using a proc

This PR fixes the bug by changing the way to define callbacks.