### PR TITLE
Implement rails/observer generator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: ruby
 rvm:
   - 2.2.6
   - 2.3.3
+gemfile:
+  - gemfiles/rails_5_0.gemfile
+  - gemfiles/rails_5_1.gemfile
 branches:
   only:
     - master

--- a/lib/generators/everett/install/USAGE
+++ b/lib/generators/everett/install/USAGE
@@ -1,8 +1,8 @@
 Description:
-    Create a Everett initializer
+    Creates an Everett initializer.
 
 Example:
-    rails generate everett:install
+    `rails generate everett:install`
 
     This will create:
         config/initializers/everett.rb

--- a/lib/generators/everett/install/install_generator.rb
+++ b/lib/generators/everett/install/install_generator.rb
@@ -1,7 +1,9 @@
+require "rails/generators/base"
+
 module Everett
   module Generators
     class InstallGenerator < ::Rails::Generators::Base
-      source_root File.expand_path("../templates", __FILE__)
+      source_root ::File.expand_path("../templates", __FILE__)
 
       def copy_initializer_file
         template "everett.rb", "config/initializers/everett.rb"

--- a/lib/generators/rails/observer/USAGE
+++ b/lib/generators/rails/observer/USAGE
@@ -1,0 +1,10 @@
+Description:
+    Stubs out a new observer. Pass the observer name, either CamelCased or
+    under_scored, as an argument.
+
+Example:
+    `rails generate observer Account`
+
+    This will create:
+        app/models/account_observer.rb
+        test/unit/account_observer_test.rb (as needed)

--- a/lib/generators/rails/observer/observer_generator.rb
+++ b/lib/generators/rails/observer/observer_generator.rb
@@ -1,0 +1,17 @@
+require "rails/generators/named_base"
+
+module Rails
+  module Generators
+    class ObserverGenerator < ::Rails::Generators::NamedBase
+      check_class_collision suffix: "Observer"
+      source_root ::File.expand_path("../templates", __FILE__)
+
+      def create_observer_file
+        destination = ::File.join("app/models", class_path, "#{file_name}_observer.rb")
+        template "observer.rb.erb", destination
+      end
+
+      hook_for :test_framework
+    end
+  end
+end

--- a/lib/generators/rails/observer/templates/observer.rb.erb
+++ b/lib/generators/rails/observer/templates/observer.rb.erb
@@ -1,0 +1,4 @@
+<% module_namespacing do -%>
+class <%= class_name %>Observer < Everett::Observer
+end
+<% end -%>

--- a/lib/generators/test_unit/observer/observer_generator.rb
+++ b/lib/generators/test_unit/observer/observer_generator.rb
@@ -1,0 +1,15 @@
+require "rails/generators/test_unit"
+
+module TestUnit
+  module Generators
+    class ObserverGenerator < ::TestUnit::Generators::Base
+      check_class_collision suffix: "ObserverTest"
+      source_root ::File.expand_path("../templates", __FILE__)
+
+      def create_test_file
+        destination = ::File.join("test/unit", class_path, "#{file_name}_observer_test.rb")
+        template "observer_test.rb.erb", destination
+      end
+    end
+  end
+end

--- a/lib/generators/test_unit/observer/templates/observer_test.rb.erb
+++ b/lib/generators/test_unit/observer/templates/observer_test.rb.erb
@@ -1,0 +1,9 @@
+require "test_helper"
+
+<% module_namespacing do -%>
+class <%= class_name %>ObserverTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end
+<% end -%>

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -2,6 +2,7 @@ require_relative 'boot'
 
 # Pick the frameworks you want:
 require "active_record/railtie"
+require "rails/test_unit/railtie"
 
 Bundler.require(*Rails.groups)
 require "everett"

--- a/spec/lib/generators/everett/install_generator_spec.rb
+++ b/spec/lib/generators/everett/install_generator_spec.rb
@@ -26,9 +26,7 @@ RSpec.describe Everett::Generators::InstallGenerator, type: :generator do
         \Z/mx
       end
 
-      it { is_expected.to exist }
-      it { is_expected.to have_correct_syntax }
-      it { is_expected.to contain expected_content }
+      it { is_expected.to exist & have_correct_syntax & contain(expected_content) }
     end
   end
 

--- a/spec/lib/generators/rails/observer_generator_spec.rb
+++ b/spec/lib/generators/rails/observer_generator_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+require "generators/rails/observer/observer_generator"
+
+RSpec.describe Rails::Generators::ObserverGenerator, type: :generator do
+  destination File.expand_path("../tmp", __FILE__)
+
+  before do
+    prepare_destination
+  end
+
+  describe "generated files" do
+    %w(foo Foo foo_bar FooBar foo/bar Foo::Bar).each do |model_name|
+      context %(when "#{model_name}" is passed) do
+        before do
+          run_generator [model_name]
+        end
+
+        describe "observer" do
+          subject { file(File.join("app/models", "#{model_name.underscore}_observer.rb")) }
+
+          let(:expected_content) do
+            <<-CONTENT.strip_heredoc
+              class #{model_name.camelize}Observer < Everett::Observer
+              end
+            CONTENT
+          end
+
+          it { is_expected.to exist & have_correct_syntax & contain(expected_content) }
+        end
+
+        describe "test" do
+          subject { file(File.join("test/unit", "#{model_name.underscore}_observer_test.rb")) }
+
+          let(:expected_content) do
+            <<-CONTENT.strip_heredoc
+              require "test_helper"
+
+              class #{model_name.camelize}ObserverTest < ActiveSupport::TestCase
+                # test "the truth" do
+                #   assert true
+                # end
+              end
+            CONTENT
+          end
+
+          it { is_expected.to exist & have_correct_syntax & contain(expected_content) }
+        end
+      end
+
+      after do
+        FileUtils.rm_rf(destination_root)
+      end
+    end
+  end
+end

--- a/spec/lib/generators/test_unit/observer_generator_spec.rb
+++ b/spec/lib/generators/test_unit/observer_generator_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+require "generators/test_unit/observer/observer_generator"
+
+RSpec.describe TestUnit::Generators::ObserverGenerator, type: :generator do
+  destination File.expand_path("../tmp", __FILE__)
+
+  before do
+    prepare_destination
+  end
+
+  describe "generated files" do
+    %w(foo Foo foo_bar FooBar foo/bar Foo::Bar).each do |model_name|
+      context %(when "#{model_name}" is passed) do
+        before do
+          run_generator [model_name]
+        end
+
+        describe "test" do
+          subject { file(File.join("test/unit", "#{model_name.underscore}_observer_test.rb")) }
+
+          let(:expected_content) do
+            <<-CONTENT.strip_heredoc
+              require "test_helper"
+
+              class #{model_name.camelize}ObserverTest < ActiveSupport::TestCase
+                # test "the truth" do
+                #   assert true
+                # end
+              end
+            CONTENT
+          end
+
+          it { is_expected.to exist & have_correct_syntax & contain(expected_content) }
+        end
+      end
+
+      after do
+        FileUtils.rm_rf(destination_root)
+      end
+    end
+  end
+end


### PR DESCRIPTION
[NOTE] Related to #4 
This PR implements generators to create a new observer and its test

```
$ rails generate observer foo
      create  app/models/foo_observer.rb
      invoke  test_unit
      create    test/unit/foo_observer_test.rb
```

```
$ cat app/models/foo_observer.rb
class FooObserver < Everett::Observer
end
```

```
$ cat test/unit/foo_observer_test.rb
require "test_helper"

class FooObserverTest < ActiveSupport::TestCase
  # test "the truth" do
  #   assert true
  # end
end
```