### PR TITLE
Fix build failure due to sqlite3

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,6 +1,9 @@
 appraise "rails-5-0" do
   gem "activerecord", "~> 5.0.0"
   gem "railties", "~> 5.0.0"
+
+  # NOTE: Deal with `Gem::LoadError: can't activate sqlite3 (~> 1.3.6)`raised in sqlite3 v1.4.x
+  gem "sqlite3", "~> 1.3.6"
 end
 
 appraise "rails-5-1" do

--- a/gemfiles/rails_5_0.gemfile
+++ b/gemfiles/rails_5_0.gemfile
@@ -4,5 +4,6 @@ source "https://rubygems.org"
 
 gem "activerecord", "~> 5.0.0"
 gem "railties", "~> 5.0.0"
+gem "sqlite3", "~> 1.3.6"
 
 gemspec path: "../"


### PR DESCRIPTION
This PR fixes sqlite3 version to 1.3.x because AR 5.0 doesn't support sqlite3 v1.4 or later.