### PR TITLE
Fix build failure due to RuboCop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 inherit_from:
-  - https://raw.githubusercontent.com/rails/rails/master/.rubocop.yml
+  - https://raw.githubusercontent.com/rails/rails/v6.0.0.rc1/.rubocop.yml
 
 AllCops:
   Exclude:
@@ -14,5 +14,5 @@ LineLength:
 Style/Documentation:
   Enabled: false
 
-Style/IndentationConsistency:
+Layout/IndentationConsistency:
   EnforcedStyle: normal

--- a/everett.gemspec
+++ b/everett.gemspec
@@ -26,7 +26,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency "pry-coolline"
   s.add_development_dependency "reek"
   s.add_development_dependency "rspec-rails"
-  s.add_development_dependency "rubocop"
+  s.add_development_dependency "rubocop", "< 0.68.0"
+  s.add_development_dependency "rubocop-performance"
   s.add_development_dependency "simplecov"
   s.add_development_dependency "sqlite3"
 end

--- a/sideci.yml
+++ b/sideci.yml
@@ -1,0 +1,4 @@
+linter:
+  rubocop:
+    gems:
+      - rubocop-performance


### PR DESCRIPTION
This PR specifies the upper version of RubCop to v0.67.0 because the config of Rails doesn't support some cops introduced in v0.68.0.